### PR TITLE
bag of tricks for speeding up training

### DIFF
--- a/mona/config.py
+++ b/mona/config.py
@@ -17,6 +17,9 @@ config = {
     # Generate data online for train/val
     "online_train": True,
     "online_val": True,
+    # Freeze the cnn backbone in the first few epochs
+    # set 0 to disable
+    "unfreeze_backbone_epoch": 400,
 
     # Select model type: Genshin or StarRail
     "model_type": "Genshin"

--- a/mona/nn/model2.py
+++ b/mona/nn/model2.py
@@ -152,3 +152,9 @@ class Model2(nn.Module):
                         else:
                             print(f"fail to load {old_idx2word[i]}")
             self.load_state_dict(model_dict)
+    def freeze_backbone(self):
+        for param in self.cnn.parameters():
+            param.requires_grad = False
+    def unfreeze_backbone(self):
+        for param in self.cnn.parameters():
+            param.requires_grad = True

--- a/mona/nn/model2.py
+++ b/mona/nn/model2.py
@@ -1,3 +1,4 @@
+import json
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -5,6 +6,7 @@ import torch.nn.functional as F
 from mona.nn.mobile_net_v3 import MobileNetV3Small
 from mona.nn.svtr import MixingBlock, SVTRNet, PositionalEncoding, SubSample
 from mona.nn.mobile_net_v3 import MobileNetV3Block
+from mona.text import index_to_word, word_to_index
 
 
 # class Model2(nn.Module):
@@ -111,3 +113,42 @@ class Model2(nn.Module):
 
         x = F.log_softmax(x, dim=2)
         return x
+    def load_can_load(self, pretrained_dict, old_idx2word_path="models/index_2_word.json"):
+        try:
+            self.load_state_dict(pretrained_dict, strict=False)
+        except Exception as e:
+            print("[warning] just load can load")
+            model_dict = self.state_dict()
+            for k, v in pretrained_dict.items():
+                if k in model_dict and v.size() == model_dict[k].size():
+                    model_dict[k] = v
+                elif k in model_dict and v.size() != model_dict[k].size():
+                    print(f"size dismatch: {k}, {v.size()} -> {model_dict[k].size()}")
+
+                    # using word map to fill the known part of the linear2
+                    if k != "linear2.weight" and k != "linear2.bias":
+                        print(f"fail to load {k}")
+                    old_idx2word = json.load(open(old_idx2word_path, "r"))
+                    # make the key from str -> num
+                    old_idx2word = {int(k): v for k, v in old_idx2word.items()}
+                    old_word2idx = {}
+                    for idx, word in old_idx2word.items():
+                        old_word2idx[word] = idx
+                    new_idx2word = index_to_word
+                    new_word2idx = word_to_index
+                    
+                    # just check the new word
+                    for i in range(model_dict[k].size()[0]):
+                        if new_idx2word[i] not in old_word2idx:
+                            print(f"{i} new word: {new_idx2word[i]}")
+
+                    # for linear2.x's matrix
+                    # from [xx, ] -> [xx+m, ], where m is the number of new words
+                    for i in range(v.size()[0]):
+                        if old_idx2word[i] in new_word2idx:
+                            new_i = new_word2idx[old_idx2word[i]]
+                            model_dict[k][new_i] = v[i]
+                            # print(f"load {old_idx2word[i]} -> {new_idx2word[new_i]}")
+                        else:
+                            print(f"fail to load {old_idx2word[i]}")
+            self.load_state_dict(model_dict)

--- a/train.py
+++ b/train.py
@@ -106,8 +106,11 @@ def train():
     print_per = config["print_per"]
     save_per = config["save_per"]
     batch = 0
+    net.freeze_backbone()
     start_time = datetime.datetime.now()
     for epoch in range(epoch):
+        if epoch == config["unfreeze_backbone_epoch"]:
+            net.unfreeze_backbone()
         for x, label in train_loader:
             optimizer.zero_grad()
             target_vector, target_lengths = get_target(label)

--- a/train.py
+++ b/train.py
@@ -127,11 +127,11 @@ def train():
 
             cur_time = datetime.datetime.now()
 
-            if (batch + 1) % print_per == 0:
+            if batch % print_per == 0 and batch != 0:
                 tput = batch_size * batch / (cur_time - start_time).total_seconds()
                 print(f"{cur_time} e{epoch} #{batch} tput: {tput} loss: {loss.item()}")
 
-            if (batch + 1) % save_per == 0:
+            if batch % save_per == 0 and batch != 0:
                 print("Validating and checkpointing")
                 rate = validate(net, validate_loader)
                 print(f"{cur_time} rate: {rate * 100}%")

--- a/train.py
+++ b/train.py
@@ -83,7 +83,7 @@ def train():
 
         transforms.RandomApply([
             transforms.RandomCrop(size=(31, 383)),
-            transforms.Resize((32, 384)),
+            transforms.Resize((32, 384), antialias=True),
             ], p=0.5),
 
         transforms.RandomApply([AddGaussianNoise(mean=0, std=1/255)], p=0.5),

--- a/train.py
+++ b/train.py
@@ -70,7 +70,8 @@ def train():
     #     out_channels=len(index_to_word)
     # ).to(device)
     if config["pretrain"]:
-        net.load_state_dict(torch.load(f"models/{config['pretrain_name']}"))
+        # assume the old index_to_word is in "models/index_2_word.json"
+        net.load_can_load(torch.load(f"models/{config['pretrain_name']}"))
 
     data_aug_transform = transforms.Compose([
         transforms.RandomApply([


### PR DESCRIPTION
添加了若干修改去修复问题或加速模型训练
## 移除高版本torch的反走样warning
## 修复了训练时的batch index需要+1的问题
## 对模型添加了load_can_load方法以实现尽可能得加载预训练模型中的权重
出现了新字之后，注意到仅有linear2的size发生了变动，故load_can_load：
1. 对于前面size相同的layer，直接load
2. 对于linear2，利用导出onnx时旧的index-word映射，及训练时新的index-word映射，将相同word中旧的linear2矩阵及偏置中的行填充到新的linear2矩阵及偏置的行中。
可以使得初始loss减小一个数量级以上。
![image](https://github.com/wormtql/yas-train/assets/30763045/6341ab10-e459-4341-a9f2-0d4476d8bae2)
![image](https://github.com/wormtql/yas-train/assets/30763045/12bfd749-0018-4cc9-95f6-004630a7ff43)
## 添加了训练初期冻结cnn的选项及实现
