### PR TITLE
chore: batch count up from 1

### DIFF
--- a/train.py
+++ b/train.py
@@ -105,7 +105,7 @@ def train():
     epoch = config["epoch"]
     print_per = config["print_per"]
     save_per = config["save_per"]
-    batch = 0
+    batch = 1
     net.freeze_backbone()
     start_time = datetime.datetime.now()
     for epoch in range(epoch):
@@ -131,11 +131,11 @@ def train():
 
             cur_time = datetime.datetime.now()
 
-            if batch % print_per == 0 and batch != 0:
+            if batch % print_per == 0:
                 tput = batch_size * batch / (cur_time - start_time).total_seconds()
                 print(f"{cur_time} e{epoch} #{batch} tput: {tput} loss: {loss.item()}")
 
-            if batch % save_per == 0 and batch != 0:
+            if batch % save_per == 0:
                 print("Validating and checkpointing")
                 rate = validate(net, validate_loader)
                 print(f"{cur_time} rate: {rate * 100}%")


### PR DESCRIPTION
在这个配置下：
```json
{
  "batch_size": 128,
  "print_per": 100,
  "save_per": 2000,
  "train_size": 256000,
}
```
若 batch 从 0 开始计数，则 2000 个 batch 实际上只能计数到 1999，要看到日志输出和保存模型需要再多训练一个 batch。
等到 batch 计数到 2000 时，实际上已经是新的一轮数据集里训练了一个 batch 后的模型了，和配置的预期对不上。

所以这里建议让batch 从 1 开始计数， batch 从 1 开始计数有两个好处：
- 可以避免后面为 batch == 0 的情况加额外的判断
- 可以让 batch 和数据集的配置匹配
